### PR TITLE
fix(firewall): stop percent-encoding rule brackets on Update

### DIFF
--- a/pkg/hrobot/firewall.go
+++ b/pkg/hrobot/firewall.go
@@ -79,6 +79,18 @@ type UpdateConfig struct {
 }
 
 // Update updates the firewall configuration for a server.
+//
+// Hetzner's Robot API expects the per-rule form fields to be encoded
+// with LITERAL square brackets in the keys (e.g.
+// `rules[input][0][dst_port]=22`). Go's `url.Values.Encode()`
+// percent-encodes `[` and `]`, which Hetzner then silently ignores —
+// the top-level `status` / `whitelist_hos` fields are accepted but
+// every per-rule field (`dst_port`, `src_ip`, `protocol`, etc.) ends
+// up null on the server, so the firewall falls open. See the
+// `UpdateTemplate` / `CreateTemplate` paths in this same file which
+// already use `PostRaw` for exactly this reason; `Update` was the
+// lone path that still routed through `Post` + `MergeValues` and
+// re-encoded the brackets.
 func (f *FirewallService) Update(ctx context.Context, serverID ServerID, config UpdateConfig) (*FirewallConfig, error) {
 	path := fmt.Sprintf("/firewall/%s", serverID.String())
 
@@ -97,29 +109,33 @@ func (f *FirewallService) Update(ctx context.Context, serverID ServerID, config 
 		encoder.AddOutputRule(ruleData)
 	}
 
-	// Add status and whitelist settings
-	additional := url.Values{}
-	additional.Set("status", string(config.Status))
-	if config.WhitelistHOS {
-		additional.Set("whitelist_hos", "true")
-	} else {
-		additional.Set("whitelist_hos", "false")
-	}
-	if config.FilterIPv6 {
-		additional.Set("filter_ipv6", "true")
-	} else {
-		additional.Set("filter_ipv6", "false")
+	// Non-rule fields go alongside the encoded rules in the same
+	// request body. `EncodeToString` keeps the rule keys' brackets
+	// literal so Hetzner actually parses them.
+	additional := map[string]string{
+		"status":       string(config.Status),
+		"whitelist_hos": boolToString(config.WhitelistHOS),
+		"filter_ipv6":  boolToString(config.FilterIPv6),
 	}
 
-	formData := encoder.MergeValues(additional)
+	formData := encoder.EncodeToString(additional)
 
 	var result FirewallConfig
-	err := f.client.Post(ctx, path, formData, &result)
+	err := f.client.PostRaw(ctx, path, formData, &result)
 	if err != nil {
 		return nil, err
 	}
 
 	return &result, nil
+}
+
+// boolToString returns "true" / "false" — the two strings Hetzner's
+// Robot API accepts for boolean form fields.
+func boolToString(b bool) string {
+	if b {
+		return "true"
+	}
+	return "false"
 }
 
 // encodeRule converts a FirewallRule to a map for URL encoding.


### PR DESCRIPTION
## Summary

`hrobot_firewall` resource `Update` silently ships an **open firewall** — every named rule loses its `dst_port` / `src_ip` / `protocol` constraints at the API boundary, so a rule that looks like `allow-ssh → tcp/22 from <CIDR>` actually ends up as `accept all TCP from anywhere`.

Root cause: `FirewallService.Update` routes the form body through
`FirewallRuleEncoder.MergeValues(additional url.Values) url.Values`
which re-parses the raw encoded string back into a `url.Values` map,
then hands it to `Client.Post` which calls `data.Encode()` and
percent-encodes every `[` / `]` in the keys. Hetzner's Robot API
happily parses the top-level `status` / `whitelist_hos` fields
(no brackets) but silently drops every per-rule field (`dst_port`,
`src_ip`, `protocol`, ...). The `UpdateTemplate` / `CreateTemplate`
paths in the same file already use `Client.PostRaw` +
`FirewallRuleEncoder.EncodeToString` — `Update` was the lone remaining
caller that still went through `Post` + `MergeValues`.

## Evidence

On a live server I deployed an `hrobot_firewall` resource with this
Terraform config (server ID and server IP redacted):

\`\`\`hcl
resource "hrobot_firewall" "example" {
  server_id                  = var.server_id
  whitelist_hetzner_services = true
  input_rules = [
    {
      name             = "allow-ssh"
      ip_version       = "ipv4"
      action           = "accept"
      protocol         = "tcp"
      destination_port = "22"
      source_ips       = ["203.0.113.0/24"]
    },
    # ...
  ]
}
\`\`\`

After \`tofu apply\` the Robot API returns:

\`\`\`json
{
  "firewall": {
    "status": "active",
    "rules": {
      "input": [
        {
          "name": "allow-ssh",
          "dst_ip": null,
          "src_ip": null,        // ← expected 203.0.113.0/24
          "dst_port": null,      // ← expected "22"
          "src_port": null,
          "protocol": "tcp",
          "tcp_flags": null,
          "action": "accept"
        },
        // ...
      ]
    }
  }
}
\`\`\`

Only `name` / `protocol` / `action` make it through because they're
top-level fields in the form; the per-rule `dst_port` / `src_ip` etc.
get dropped on the Hetzner side.

## Fix

Have \`Update\` build the body the same way \`UpdateTemplate\` already
does:

\`\`\`go
formData := encoder.EncodeToString(additional)       // raw string, literal brackets
err := f.client.PostRaw(ctx, path, formData, &result) // no re-encoding
\`\`\`

Drops the \`MergeValues\` + \`Post\` path. The \`MergeValues\` helper
itself is already marked \`// deprecated\` in \`urlencode/firewall.go\`
and can be removed in a follow-up.

## Regression tests

Added \`pkg/hrobot/internal/urlencode/firewall_test.go\` covering two
invariants:

1. \`Encode()\` / \`EncodeToString()\` output MUST contain literal
   \`rules[input][0][dst_port]=22\` style keys.
2. The output MUST NOT contain \`%5B\` / \`%5D\` anywhere.

Any future refactor that accidentally round-trips through
\`url.Values.Encode()\` now fails loudly in CI instead of silently
shipping an open firewall.

## Risk

- No API surface change, no provider schema change. This is purely
  a wire-encoding fix.
- Existing users who have a state file with rules that look like
  they are restricted (but are actually wide-open on the Hetzner
  side) will see the next \`tofu apply\` produce a "no-op" plan,
  because the Terraform state matches what they asked for — but
  behind the scenes the firewall will now actually enforce what
  the config says.
- Recommend users audit their current Hetzner firewall state via
  \`curl -u $HROBOT_USERNAME:$HROBOT_PASSWORD https://robot-ws.your-server.de/firewall/<ip>\`
  after upgrading to check whether any rule degraded from
  "wide-open-TCP" to "restricted-as-configured" in a way that
  breaks their expectations.

## Test plan

- [x] \`go build ./...\`
- [x] \`go test ./pkg/hrobot/internal/urlencode/...\` (new tests pass)
- [x] \`go test ./pkg/hrobot/...\` (existing package tests still pass)
- [ ] Once merged + released, verify on live server that the next
      \`tofu apply\` produces the expected \`dst_port\`/\`src_ip\`
      values in the Robot API response.